### PR TITLE
Propagate DID + trunk_info to sources post_processing method

### DIFF
--- a/includes/processors/superfecta_multi.php
+++ b/includes/processors/superfecta_multi.php
@@ -364,6 +364,7 @@ class superfecta_multi extends superfecta_base {
                 $source_class = NEW $source_name;
                 $source_class->set_DB($this->db);
                 $source_class->setDebug($this->isDebug());
+ 	            $source_class->set_TrunkInfo($this->trunk_info);	// not really needed for 'send_to' current sources, but it doesnt hurt to get environment infos to be propagated for future uses.....
                 $source_class->setDID($this->trunk_info['did']);	// needed for notifications 'send_to' sources (XBMC, Growl, Dreambox...)
                if (method_exists($source_class, 'post_processing')) {
                     $source_class->post_processing($this->isCacheFound(), NULL, $caller_id, $run_param, $this->trunk_info['callerid']);

--- a/includes/processors/superfecta_multi.php
+++ b/includes/processors/superfecta_multi.php
@@ -364,7 +364,8 @@ class superfecta_multi extends superfecta_base {
                 $source_class = NEW $source_name;
                 $source_class->set_DB($this->db);
                 $source_class->setDebug($this->isDebug());
-                if (method_exists($source_class, 'post_processing')) {
+                $source_class->setDID($this->trunk_info['did']);	// needed for notifications 'send_to' sources (XBMC, Growl, Dreambox...)
+               if (method_exists($source_class, 'post_processing')) {
                     $source_class->post_processing($this->isCacheFound(), NULL, $caller_id, $run_param, $this->trunk_info['callerid']);
                 } else {
                     print "Method 'post_processing' doesn't exist<br\>\n";

--- a/includes/processors/superfecta_single.php
+++ b/includes/processors/superfecta_single.php
@@ -99,6 +99,7 @@ class superfecta_single extends superfecta_base {
                 $source_class = NEW $source_name;
                 $source_class->set_DB($this->db);
                 $source_class->setDebug($this->getDebug());
+	            $source_class->set_TrunkInfo($this->trunk_info);	// not really needed for 'send_to' current sources, but it doesnt hurt to get environment infos to be propagated for future uses.....
                 $source_class->setDID($this->trunk_info['did']);	// needed for notifications 'send_to' sources (XBMC, Growl, Dreambox...)
                 if (method_exists($source_class, 'post_processing')) {
                     $caller_id = $source_class->post_processing($this->isCacheFound(), NULL, $this->first_caller_id, $run_param, $this->trunk_info['callerid']);

--- a/includes/processors/superfecta_single.php
+++ b/includes/processors/superfecta_single.php
@@ -99,6 +99,7 @@ class superfecta_single extends superfecta_base {
                 $source_class = NEW $source_name;
                 $source_class->set_DB($this->db);
                 $source_class->setDebug($this->getDebug());
+                $source_class->setDID($this->trunk_info['did']);	// needed for notifications 'send_to' sources (XBMC, Growl, Dreambox...)
                 if (method_exists($source_class, 'post_processing')) {
                     $caller_id = $source_class->post_processing($this->isCacheFound(), NULL, $this->first_caller_id, $run_param, $this->trunk_info['callerid']);
                 } else {


### PR DESCRIPTION
Hi guys 

This fix allows 'SendTo' types sources (ie Growl,XBMC,Dreambox) to display the incoming line number (DID).
 (this feature having been removed when you'd rewritten the sources to now extend the superfecta_base class). It also propagate the trunk_info , just in case.

BTW As a POSSA team member, I guess I could just push to the develop branch, but i prefer to still make PR and having you reviewing my commits.. Right ?

PS: It has been a long time since my first commits, and when you kindly teached me GIT... :-)
 Now I'm really used to it, and just love it... 

cheers