### PR TITLE
Moved the UTF-8 conversion up to add the converted result to the cache

### DIFF
--- a/Superfecta.class.php
+++ b/Superfecta.class.php
@@ -197,6 +197,14 @@ class Superfecta implements \BMO {
 				$callerid = preg_replace("/[\";']/", "", $callerid);
 				//limit caller id to the first 60 char
 				$callerid = substr($callerid, 0, 60);
+				
+				// Display issues on phones and CDR with special characters
+				// convert CNAM to UTF-8 to fix
+				if (function_exists('mb_convert_encoding')) {
+					$this->out("Converting result to UTF-8");
+					$callerid = mb_convert_encoding($callerid, "UTF-8");
+				}
+				
 				//send off
 				$superfecta->send_results($callerid);
 			}
@@ -207,13 +215,6 @@ class Superfecta implements \BMO {
 				$callerid = $spam_text;
 			} else {
 				$callerid = $spam_text . " " . $superfecta->get_Prefix() . $callerid;
-			}
-
-			// Display issues on phones and CDR with special characters
-			// convert CNAM to UTF-8 to fix
-			if ($found && function_exists('mb_convert_encoding')) {
-				$this->out("Converting result to UTF-8");
-				$callerid = mb_convert_encoding($callerid, "UTF-8");
 			}
 
 			//Set Spam Destination


### PR DESCRIPTION
I discovered that the UTF8 converted string is set for the first lookup. But afterwards it is read out of cache and there it is still not converted. Means I got wrong (unconverted) results

The patch moves the conversion up so it is saved as converted to the cache and also readit like this later.
