### PR TITLE
Fixed UKPhoneInfo.com not working as they now enforce HTTPS

### DIFF
--- a/sources/source-UKPhoneInfo_UK.module
+++ b/sources/source-UKPhoneInfo_UK.module
@@ -25,7 +25,7 @@ class UKPhoneInfo_UK extends superfecta_base {
             $this->DebugPrint("Skipping Source - Non UK number: {$thenumber}");
         } else {
             $this->DebugPrint('Searching UKPhoneInfo ...');
-            $url = "http://www.ukphoneinfo.com/search?q={$thenumber}";
+            $url = "https://www.ukphoneinfo.com/search?q={$thenumber}";
             if ($this->SearchURL($url, "=<h2[^>]*>(.*)</h2>=siU", $match)) {
                 $caller_id = $this->ExtractMatch($match);
             }


### PR DESCRIPTION
UKPhoneInfo UK stopped working as they now redirect everything to HTTPS. Seems the module doesn't handle redirects so i've changed the URL from http:// to https://

Have confirmed that it now works as expected on FreePBX 10